### PR TITLE
Rework serverInfo decoder to use urllib

### DIFF
--- a/Collectors/decoding.py
+++ b/Collectors/decoding.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import requests
 import struct
 import sys
+import urllib.parse
 
 header = namedtuple("header", ["code", "pseq", "plen", "server_start"])
 mapheader = namedtuple("mapheader", ["dictID", "info"])
@@ -93,12 +94,12 @@ def revAuthorizationInfo(authinfo):
     return str.encode(message)
 
 def serverInfo(message, addr):
-    r = message.split(b'&')
-    pgm = r[1].split(b'=')[1]
-    ver = r[2].split(b'=')[1]
-    inst = r[3].split(b'=')[1]
-    port = r[4].split(b'=')[1]
-    site = r[5].split(b'=')[1]
+    r = dict(urllib.parse.parse_qsl(message))
+    pgm  = r.get(b'pgm',  None)
+    ver  = r.get(b'ver',  None)
+    inst = r.get(b'inst', None)
+    port = r.get(b'port', None)
+    site = r.get(b'site', None)
     return srvinfo(pgm, ver, inst, port, site, addr)
 
 def revServerInfo(serverInfoStruct):


### PR DESCRIPTION
Field order changed after XRootD v5.0.2, probably in https://github.com/xrootd/xrootd/commit/7421899636e16311bb483775c6c94ac839db38c1