### PR TITLE
Fix set-output GHA deprecation warning (Software-5354)

### DIFF
--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - name: make date tag
       id: mkdatetag
-      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
+      run: echo "dtag=$(date +%Y%m%d-%H%M)" >> $GITHUB_OUTPUT
 
   build:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
         # This causes the tag_list array to be comma-separated below,
         # which is required for build-push-action
         IFS=,
-        echo "::set-output name=taglist::${tag_list[*]}"
+        echo "taglist=${tag_list[*]}" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Fix set-output GHA deprecation warning in build-sw-container.yml