### PR TITLE
Removing throughput

### DIFF
--- a/Collectors/DetailedCollector.py
+++ b/Collectors/DetailedCollector.py
@@ -261,11 +261,6 @@ class DetailedCollector(UdpCollector.UdpCollector):
             rec['read_vector_operations'] = fileClose.ops.readv
             # read_vector_sigma (optional)
             # server_username (optional)
-            # throughput (optional)
-            try:
-                rec['throughput'] = (fileClose.read + fileClose.readv + fileClose.write) / rec['operation_time']
-            except ZeroDivisionError as zde:
-                rec['throughput'] = 0
             # user_fqan (optional)
             # user_role (optional)
             # write_average (optional)

--- a/Collectors/wlcg_converter.py
+++ b/Collectors/wlcg_converter.py
@@ -133,7 +133,6 @@ def Convert(source_record):
                       "read_vector_min",
                       "read_vector_operations",
                       "read_vector_sigma",
-                      "throughput",
                       "write_average",
                       "write_bytes_at_close",
                       "write_max",


### PR DESCRIPTION
The throughput is based on the XrootD timestamp, and those timestamps are not precise enough to calculate the throughput.