### PR TITLE
add support for eainfo streams

### DIFF
--- a/Collectors/decoding.py
+++ b/Collectors/decoding.py
@@ -15,6 +15,7 @@ srvinfo  = namedtuple("srvinfo", ["program", "version", "instance", "port", "sit
 prginfo  = namedtuple("prginfo", ["xfn", "tod", "sz", "at", "ct", "mt", "fn"])
 xfrinfo  = namedtuple("xfrinfo", ["lfn", "tod", "sz", "tm", "op", "rc", "pd"])
 pathinfo = namedtuple("pathinfo", ["userinfo", "path"])
+eainfo   = namedtuple("eainfo", ["udid", "experiment", "activity"])
 
 fileOpen  = namedtuple("fileOpen",  ["rectype", "recFlag", "recSize", "fileID", "fileSize", "userID", "fileName"])
 fileXfr   = namedtuple("fileXfr",   ["rectype", "recFlag", "recSize", "fileID", "read", "readv", "write"])
@@ -142,6 +143,21 @@ def xfrInfo(message):
     else:
         pd = b''
     return xfrinfo([lfn, tod, sz, tm, op, rc, pd])
+
+
+def eaInfo(message, scitags_mapping):
+    if isinstance(message, str):
+        message = message.encode('utf-8')
+    r = message.split(b'&')
+    
+    udid = r[1].split(b'=')[1]
+    expc = int(r[2].split(b'=')[1]) - 1 
+    actc = int(r[3].split(b'=')[1]) - 1
+
+    experiment = scitags_maping['experiments'][expc]['expName']
+    activity = scitags_maping['experiments'][expc]['activities'][actc]['activityName']
+    return eainfo(udid, experiment, activity)   
+
 
 def gStream(message):
     # int, int, int64, null terminated string

--- a/Collectors/wlcg_converter.py
+++ b/Collectors/wlcg_converter.py
@@ -100,11 +100,17 @@ def Convert(source_record):
         to_return["user_protocol"] = source_record["protocol"]
 
     # vo
-    if "vo" in source_record:
+    if "experiment" in source_record:
+        to_return["vo"] = source_record["experiment"]
+    elif "vo" in source_record:
         to_return["vo"] = source_record["vo"]
 
     # write_bytes
     to_return["write_bytes"] = source_record['write']
+
+    # activity
+    to_return["activity"] = source_record.get('activity', 'unknown')
+
     # remote_access - boolean
     # is_transfer (optional)
     # user_fqan (optional)


### PR DESCRIPTION
This PR adds support for decoding and parsing eainfo streams  (scitags) containing activity and experiment code.
The mapping file is a JSON containing the contents of https://scitags.docs.cern.ch/api.json